### PR TITLE
Haunted Object Archive MVP — intake, vetting, storage, and gamification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,16 @@
-# Burbz OS MVP
+# Haunted Object Archive MVP
 
-Burbz OS MVP is a lightweight React + Vite interface for running an off-grid Llama AI workstation. The current prototype focuses on a desktop-style experience for local chat, offline file access, model status, and power-aware operation.
+This project is a React + Vite remake of the original haunted-object-database concept. Instead of a simple map, it focuses on a serious archival workflow for haunted object submissions, moderation, and long-term storage.
 
-## What changed in this refactor
+## MVP features
 
-- Replaced the single monolithic `React.createElement` screen with small JSX components.
-- Removed unused Tailwind/PostCSS scaffolding and a conflicting legacy stylesheet.
-- Made each dock app (`Chat`, `Vault`, `Models`, `Power`) render a focused workspace instead of only changing the title.
-- Centralized product copy and dashboard data in one module so the UI is easier to maintain.
-- Improved accessibility with clearer button state, focus styles, and more semantic structure.
+- **Detailed intake form** for haunted object submissions with provenance, chain of custody, evidence, witnesses, and a seriousness attestation.
+- **Storage house archive** that keeps every submitted form in a browsable local archive.
+- **Seriousness vetting system** that scores each submission and routes it into archived, review, or hold states.
+- **Gamified progression** with credibility XP, level titles, badges, and field quests inspired by crowd-powered contribution loops.
+- **Local persistence** via `localStorage` so the MVP works without standing up a backend.
 
-## Project structure
-
-```text
-src/
-  components/   reusable UI building blocks
-  data/         dashboard copy and mock data
-  pages/        route-level screens
-  App.jsx       app shell
-  main.jsx      React entry point
-```
-
-## Development
+## Getting started
 
 ```bash
 npm install
@@ -33,3 +22,8 @@ npm run dev
 ```bash
 npm run build
 ```
+
+## Notes
+
+- This MVP stores report data in browser storage to simulate a storage house and vetting queue.
+- A future production version could swap the local persistence layer for an API and database-backed moderation service.

--- a/src/data/hauntedMvp.js
+++ b/src/data/hauntedMvp.js
@@ -1,0 +1,108 @@
+export const starterReports = [
+  {
+    id: 'case-001',
+    objectName: 'Blackthorn Mourning Locket',
+    category: 'Jewelry',
+    origin: 'Inherited from a family estate in Providence, Rhode Island',
+    currentLocation: 'Cold storage locker B-12',
+    acquiredOn: '2025-10-13',
+    phenomena: ['Whispers', 'Temperature drop'],
+    witnessCount: 3,
+    chainOfCustody:
+      'Recovered by the estate attorney, transferred to a parish archivist, and sealed by the current custodian with a notarized hand-off.',
+    evidenceSummary:
+      'Three independent witnesses documented whispered responses, a 9°F temperature drop, and one EVP clip captured on two devices during cataloging.',
+    incidentNotes:
+      'Activity intensified when the locket was opened. The hinge now remains wax-sealed between examinations.',
+    seriousness: 'academic',
+    riskLevel: 'high',
+    attestation: true,
+    submittedBy: 'N. Alvarez',
+    status: 'archived',
+    score: 92,
+    xpAwarded: 140,
+    moderationNote: 'Full chain of custody and corroborated evidence. Eligible for permanent archive.',
+    createdAt: '2026-03-18T22:14:00.000Z',
+  },
+  {
+    id: 'case-002',
+    objectName: 'Basement Carousel Horse Fragment',
+    category: 'Artifact',
+    origin: 'Removed from a defunct fairground ride outside Tulsa, Oklahoma',
+    currentLocation: 'Quarantine shelf Q-4',
+    acquiredOn: '2026-01-28',
+    phenomena: ['Movement', 'Nightmares'],
+    witnessCount: 1,
+    chainOfCustody:
+      'Seller account and transport details were provided, but the previous owner timeline still has gaps.',
+    evidenceSummary:
+      'Single witness reports vibration after midnight and recurring dreams after touching the lacquered surface.',
+    incidentNotes:
+      'Needs corroboration from additional observers before public release.',
+    seriousness: 'investigative',
+    riskLevel: 'medium',
+    attestation: true,
+    submittedBy: 'Field Team 6',
+    status: 'review',
+    score: 68,
+    xpAwarded: 90,
+    moderationNote: 'Promising report, but supporting evidence is thin.',
+    createdAt: '2026-03-19T09:42:00.000Z',
+  },
+];
+
+export const phenomenonOptions = [
+  'Whispers',
+  'Movement',
+  'Scratches',
+  'Temperature drop',
+  'Electrical disturbance',
+  'Nightmares',
+  'Apparition',
+  'Odor',
+];
+
+export const seriousnessOptions = [
+  {
+    id: 'academic',
+    label: 'Academic archive',
+    description: 'Written for researchers with evidence and careful sourcing.',
+  },
+  {
+    id: 'investigative',
+    label: 'Investigation log',
+    description: 'Prepared for vetting, with facts separated from theory.',
+  },
+  {
+    id: 'personal',
+    label: 'Personal testimony',
+    description: 'First-hand account intended for follow-up interviews.',
+  },
+];
+
+export const levelTitles = [
+  'Night Clerk',
+  'Archive Runner',
+  'Case Steward',
+  'Relic Ranger',
+  'Custodian of Evidence',
+  'Warden of the Vault',
+];
+
+export const quests = [
+  {
+    title: 'Earn trust quickly',
+    reward: '+35 XP',
+    detail: 'Submit a report with 2+ witnesses, a chain of custody, and a serious attestation.',
+  },
+  {
+    title: 'Stabilize the archive',
+    reward: '+50 XP',
+    detail: 'Promote two review cases into the storage house after adding moderator notes.',
+  },
+  {
+    title: 'No campfire fiction',
+    reward: 'Credibility badge',
+    detail: 'Keep your rejection rate under 10% while filing three complete cases.',
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,488 +1,486 @@
 :root {
   color-scheme: dark;
   font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #e5eefc;
+  color: #e7edf9;
   background:
-    radial-gradient(circle at top, rgba(90, 120, 255, 0.28), transparent 30%),
-    linear-gradient(180deg, #08111f 0%, #040814 100%);
-  --surface: rgba(10, 18, 36, 0.88);
-  --surface-muted: rgba(255, 255, 255, 0.04);
-  --surface-strong: rgba(8, 14, 28, 0.72);
-  --border: rgba(154, 175, 255, 0.15);
-  --border-strong: rgba(159, 178, 255, 0.18);
-  --text-soft: #8b9ab8;
-  --text-primary: #f8fbff;
-  --accent: #5a75ff;
+    radial-gradient(circle at top, rgba(113, 76, 255, 0.28), transparent 28%),
+    linear-gradient(180deg, #050912 0%, #070d1a 100%);
+  --surface: rgba(9, 14, 28, 0.86);
+  --surface-2: rgba(255, 255, 255, 0.04);
+  --surface-3: rgba(11, 19, 35, 0.95);
+  --border: rgba(155, 176, 255, 0.16);
+  --accent: #8b5cf6;
+  --accent-2: #38bdf8;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --danger: #fb7185;
+  --text-soft: #9db0d1;
+  --text-strong: #f8fbff;
 }
 
 * {
   box-sizing: border-box;
 }
 
-html {
-  scroll-behavior: smooth;
+html,
+body,
+#root {
+  min-height: 100%;
 }
 
 body {
   margin: 0;
   min-width: 320px;
-  min-height: 100vh;
-  background: #040814;
+  background: #050912;
 }
 
 body,
 button,
-textarea {
+input,
+textarea,
+select {
   font: inherit;
 }
 
 button,
-textarea {
+input,
+textarea,
+select {
   border: 0;
 }
 
-button {
+button,
+select {
   color: inherit;
 }
 
+button,
+input[type='checkbox'] {
+  cursor: pointer;
+}
+
 button:focus-visible,
-textarea:focus-visible {
-  outline: 2px solid #7dcfff;
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid #7dd3fc;
   outline-offset: 2px;
 }
 
-#root {
-  min-height: 100vh;
-}
-
-.os-shell {
+.haunted-app {
   min-height: 100vh;
   padding: 32px;
   background:
-    linear-gradient(135deg, rgba(64, 91, 255, 0.1), transparent 45%),
-    radial-gradient(circle at bottom right, rgba(41, 214, 169, 0.12), transparent 20%);
+    linear-gradient(135deg, rgba(139, 92, 246, 0.08), transparent 42%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.12), transparent 24%);
 }
 
-.hero-panel {
-  display: flex;
-  justify-content: space-between;
+.hero-panel,
+.panel,
+.metric-card,
+.report-card,
+.storage-card,
+.quest-list article {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  backdrop-filter: blur(18px);
+}
+
+.haunted-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
   gap: 24px;
-  align-items: flex-start;
-  margin-bottom: 24px;
   padding: 28px;
-  border: 1px solid var(--border-strong);
-  border-radius: 24px;
-  background: rgba(7, 14, 28, 0.82);
+  border-radius: 28px;
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
 }
 
-.eyebrow {
-  margin: 0 0 10px;
-  color: #7dcfff;
+.eyebrow,
+.section-title p,
+.metric-card span,
+.report-status,
+.storage-top p,
+.level-label,
+.quest-list article p,
+.filter-row button,
+.report-card dt {
+  margin: 0;
+  color: var(--text-soft);
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  font-size: 0.8rem;
+  font-size: 0.76rem;
 }
 
-.hero-panel h1,
-.hero-focus h2 {
+.haunted-hero h1,
+.section-title h2,
+.hero-focus h2,
+.report-card h3,
+.storage-card h3,
+.quest-list article h3,
+.level-panel h3 {
   margin: 0;
 }
 
-.hero-panel h1 {
-  max-width: 720px;
-  font-size: clamp(2.4rem, 5vw, 4.6rem);
+.haunted-hero h1 {
+  max-width: 740px;
+  font-size: clamp(2.5rem, 5vw, 4.8rem);
   line-height: 0.95;
 }
 
-.hero-copy {
-  max-width: 680px;
-  margin: 16px 0 0;
-  color: #98a8c7;
-  font-size: 1.05rem;
+.hero-copy,
+.hero-focus p,
+.section-title span,
+.metric-card p,
+.report-copy,
+.moderation-note,
+.rubric-list p,
+.level-panel p,
+.quest-list article span,
+.storage-card li,
+.flash-message,
+.empty-state {
+  color: #d1dcf1;
   line-height: 1.6;
+}
+
+.hero-copy {
+  max-width: 720px;
+  margin: 16px 0 0;
+  color: #a9bcdd;
+  font-size: 1.05rem;
 }
 
 .hero-focus {
   margin-top: 24px;
-  max-width: 640px;
+  max-width: 680px;
   padding: 18px 20px;
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: 22px;
   background: rgba(255, 255, 255, 0.03);
 }
 
-.hero-focus-label,
-.hero-stats span,
-.status-list span,
-.file-row span,
-.prompt-box span,
-.message-role,
-.panel-caption {
-  color: var(--text-soft);
+.hero-focus-label {
+  color: var(--accent-2);
   font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
 }
 
-.hero-focus h2 {
-  margin-top: 10px;
-  font-size: 1.35rem;
-  color: var(--text-primary);
-}
-
-.hero-focus p,
-.data-card p,
-.file-row--stacked p {
-  margin: 10px 0 0;
-  color: #d4def3;
-  line-height: 1.6;
-}
-
-.hero-stats {
+.haunted-metrics {
   display: grid;
-  grid-template-columns: repeat(3, minmax(130px, 1fr));
-  gap: 12px;
-  min-width: min(340px, 100%);
-}
-
-.hero-stats article,
-.window,
-.dock {
-  border: 1px solid var(--border);
-  background: var(--surface);
-  backdrop-filter: blur(14px);
-}
-
-.hero-stats article {
-  padding: 16px;
-  border-radius: 18px;
-}
-
-.hero-stats strong,
-.status-list strong,
-.file-row strong,
-.data-card strong {
-  display: block;
-  margin-top: 8px;
-  color: var(--text-primary);
-  font-size: 1rem;
-}
-
-.desktop-frame {
-  display: grid;
-  grid-template-columns: 88px 1fr;
-  gap: 18px;
-  min-height: 70vh;
-}
-
-.dock {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 18px 12px;
-  border-radius: 22px;
-}
-
-.dock-brand {
-  display: grid;
-  place-items: center;
-  width: 52px;
-  height: 52px;
-  margin: 0 auto 8px;
-  border-radius: 16px;
-  background: linear-gradient(135deg, #70e1ff, var(--accent));
-  color: #08111f;
-  font-weight: 800;
-}
-
-.dock-app {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  padding: 12px 6px;
-  border-radius: 18px;
-  background: transparent;
-  color: #aab7d3;
-  cursor: pointer;
-  transition: 180ms ease;
-}
-
-.dock-app.is-active,
-.dock-app:hover,
-.chip:hover,
-.prompt-actions button:hover,
-.ghost-button:hover {
-  background: rgba(90, 117, 255, 0.18);
-  color: #fff;
-}
-
-.dock-icon {
-  display: grid;
-  place-items: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.06);
-  font-size: 1rem;
-}
-
-.dock-app span:last-child {
-  font-size: 0.72rem;
-  text-align: center;
-}
-
-.workspace {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.topbar,
-.window-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.topbar {
-  padding: 14px 18px;
-  border: 1px solid rgba(154, 175, 255, 0.12);
-  border-radius: 18px;
-  background: var(--surface-strong);
-  color: #cdd8ef;
-}
-
-.topbar > div:first-child {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.topbar-meta {
-  display: flex;
-  gap: 16px;
-  color: #8d9cba;
-  font-size: 0.88rem;
-}
-
-.status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: #34d399;
-  box-shadow: 0 0 18px rgba(52, 211, 153, 0.8);
-}
-
-.window-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.9fr);
-  gap: 16px;
-  flex: 1;
-}
-
-.window {
-  border-radius: 24px;
-  padding: 18px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
-}
-
-.window-header {
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.window-header p {
-  margin: 0;
-  font-weight: 600;
-}
-
-.window-actions {
-  display: inline-flex;
-  gap: 8px;
-}
-
-.window-controls {
-  display: flex;
-  gap: 8px;
-}
-
-.window-controls span {
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.2);
-}
-
-.conversation,
-.card-grid,
-.sidebar-stack,
-.chip-list,
-.status-list,
-.file-list {
-  display: grid;
-  gap: 12px;
-}
-
-.message {
-  padding: 16px;
-  border-radius: 18px;
-  background: var(--surface-muted);
-}
-
-.message p,
-.message ul {
-  margin: 0;
-}
-
-.message ul {
-  padding-left: 18px;
-  color: #dbe6ff;
-}
-
-.message.assistant {
-  border: 1px solid rgba(85, 213, 255, 0.15);
-}
-
-.message.user {
-  border: 1px solid rgba(111, 119, 255, 0.16);
-  background: rgba(90, 117, 255, 0.12);
-}
-
-.message.soft {
-  border: 1px dashed rgba(255, 255, 255, 0.12);
-}
-
-.prompt-box {
-  display: block;
-  margin-top: 18px;
-}
-
-.prompt-box textarea {
-  width: 100%;
-  margin-top: 10px;
-  padding: 14px;
-  border: 1px solid rgba(154, 175, 255, 0.16);
-  border-radius: 16px;
-  resize: vertical;
-  color: #eff5ff;
-  background: rgba(4, 8, 20, 0.82);
-}
-
-.prompt-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 14px;
-}
-
-.prompt-actions button,
-.chip {
-  padding: 12px 16px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.06);
-  cursor: pointer;
-  transition: 180ms ease;
-}
-
-.ghost-button {
-  background: rgba(255, 255, 255, 0.03) !important;
-  border: 1px solid rgba(154, 175, 255, 0.14) !important;
-}
-
-.window-header.compact {
-  margin-bottom: 14px;
-}
-
-.chip {
-  text-align: left;
-}
-
-.status-list div,
-.file-row,
-.data-card {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 16px;
-  background: var(--surface-muted);
-}
-
-.file-row div,
-.data-card {
-  display: grid;
-  gap: 4px;
-}
-
-.file-row--stacked {
-  align-items: flex-start;
-  flex-direction: column;
-}
-
-.file-row--stacked strong {
-  margin-top: 0;
-}
-
-.file-list--detailed {
   gap: 14px;
 }
 
-.card-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+.metric-card {
+  padding: 18px;
+  border-radius: 20px;
 }
 
-.data-card span {
+.metric-card strong {
+  display: block;
+  margin-top: 8px;
+  color: var(--text-strong);
+  font-size: 2rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.lower-grid {
+  align-items: start;
+}
+
+.panel {
+  padding: 24px;
+  border-radius: 26px;
+}
+
+.section-title {
+  margin-bottom: 20px;
+}
+
+.section-title h2 {
+  margin-top: 6px;
+  font-size: 1.7rem;
+}
+
+.intake-form {
+  display: grid;
+  gap: 14px;
+}
+
+.intake-form label,
+.intake-form fieldset {
+  display: grid;
+  gap: 8px;
+  color: var(--text-strong);
+}
+
+.form-split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.form-split.triple {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: var(--surface-2);
+  color: var(--text-strong);
+}
+
+textarea {
+  min-height: 112px;
+  resize: vertical;
+}
+
+fieldset {
+  margin: 0;
+  padding: 14px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+legend {
+  padding: 0 8px;
+}
+
+.check-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.check-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.check-pill input {
+  width: auto;
+  margin: 0;
+}
+
+.attestation {
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(52, 211, 153, 0.08);
+}
+
+.primary-button,
+.card-actions button,
+.filter-row button {
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #fff;
+  font-weight: 700;
+}
+
+.ghost-button,
+.filter-row button {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.filter-row button.is-active {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+}
+
+.flash-message {
+  margin: 0;
+  padding: 14px 16px;
+  border: 1px solid rgba(56, 189, 248, 0.25);
+  border-radius: 16px;
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.rubric-list,
+.queue-stack,
+.storage-grid,
+.quest-list {
+  display: grid;
+  gap: 14px;
+}
+
+.rubric-list div,
+.level-panel {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.report-card {
+  padding: 16px;
+  border-radius: 22px;
+}
+
+.status-review {
+  border-color: rgba(251, 191, 36, 0.28);
+}
+
+.status-hold {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.status-archived {
+  border-color: rgba(52, 211, 153, 0.28);
+}
+
+.report-card-top,
+.storage-top,
+.level-panel,
+.card-actions,
+.filter-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.report-card dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.report-card dd {
+  margin: 6px 0 0;
+  color: var(--text-strong);
+}
+
+.score-pill,
+.storage-top span,
+.badge-pill {
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(139, 92, 246, 0.16);
+  color: #efe7ff;
+  white-space: nowrap;
+}
+
+.card-actions {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+}
+
+.card-actions button {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.storage-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.storage-card {
+  padding: 18px;
+  border-radius: 22px;
+}
+
+.storage-card ul {
+  margin: 16px 0 0;
+  padding-left: 18px;
+}
+
+.level-progress {
+  min-width: min(220px, 100%);
+}
+
+.progress-bar {
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--success), var(--accent-2));
+}
+
+.badge-wrap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 18px 0;
+}
+
+.badge-pill.muted {
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-soft);
-  font-size: 0.85rem;
+}
+
+.quest-list article {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border-radius: 22px;
+}
+
+.empty-state {
+  margin: 0;
 }
 
 @media (max-width: 1100px) {
-  .hero-panel,
-  .window-grid {
+  .haunted-hero,
+  .dashboard-grid {
     grid-template-columns: 1fr;
   }
 
-  .hero-panel {
-    flex-direction: column;
+  .form-split.triple,
+  .form-split,
+  .storage-grid {
+    grid-template-columns: 1fr;
   }
 
-  .hero-stats {
-    min-width: 0;
-    width: 100%;
+  .level-panel,
+  .report-card-top,
+  .storage-top {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 
-@media (max-width: 800px) {
-  .os-shell {
+@media (max-width: 720px) {
+  .haunted-app {
     padding: 18px;
   }
 
-  .desktop-frame {
+  .panel,
+  .haunted-hero {
+    padding: 18px;
+    border-radius: 20px;
+  }
+
+  .haunted-hero h1 {
+    font-size: 2.3rem;
+  }
+
+  .report-card dl {
     grid-template-columns: 1fr;
   }
 
-  .dock {
-    flex-direction: row;
-    overflow-x: auto;
-  }
-
-  .dock-brand {
-    flex: 0 0 auto;
-  }
-
-  .dock-app {
-    min-width: 88px;
-  }
-
-  .topbar,
-  .topbar-meta,
-  .prompt-actions,
-  .window-header,
-  .status-list div,
-  .file-row {
-    flex-direction: column;
-    align-items: flex-start;
+  .filter-row {
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,99 +1,629 @@
-import { useMemo, useState } from 'react';
-import { AppWorkspace, FileList, SystemHealthList } from '../components/AppWorkspace';
-import { Dock } from '../components/Dock';
-import { StatusCardList } from '../components/StatusCardList';
-import { WindowPanel } from '../components/WindowPanel';
-import { apps, quickPrompts, systemStats } from '../data/dashboard';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  levelTitles,
+  phenomenonOptions,
+  quests,
+  seriousnessOptions,
+  starterReports,
+} from '../data/hauntedMvp';
 
-const defaultPrompt =
-  'How do I run a local Llama assistant entirely offline with low power draw?';
+const storageKey = 'haunted-object-mvp-reports';
+const jokePattern = /\b(?:lol|lmao|haha|prank|meme|bro|just kidding|fake|creepypasta)\b/i;
+const levelStep = 180;
 
-function TopBar({ activeApp }) {
+const emptyForm = {
+  objectName: '',
+  category: '',
+  origin: '',
+  currentLocation: '',
+  acquiredOn: '',
+  phenomena: [],
+  witnessCount: 1,
+  chainOfCustody: '',
+  evidenceSummary: '',
+  incidentNotes: '',
+  seriousness: 'academic',
+  riskLevel: 'medium',
+  attestation: false,
+  submittedBy: '',
+};
+
+function loadReports() {
+  if (typeof window === 'undefined') {
+    return starterReports;
+  }
+
+  const saved = window.localStorage.getItem(storageKey);
+  if (!saved) {
+    return starterReports;
+  }
+
+  try {
+    const parsed = JSON.parse(saved);
+    return Array.isArray(parsed) && parsed.length ? parsed : starterReports;
+  } catch {
+    return starterReports;
+  }
+}
+
+function calculateScore(form) {
+  let score = 0;
+  const notes = [];
+  const longEvidence = form.evidenceSummary.trim().length >= 120;
+  const longCustody = form.chainOfCustody.trim().length >= 90;
+  const longOrigin = form.origin.trim().length >= 50;
+  const hasMultiplePhenomena = form.phenomena.length >= 2;
+  const hasWitnesses = Number(form.witnessCount) >= 2;
+  const textBundle = `${form.objectName} ${form.origin} ${form.evidenceSummary} ${form.incidentNotes}`;
+  const flaggedAsJoke = jokePattern.test(textBundle);
+
+  if (form.objectName.trim().length >= 5) score += 10;
+  if (form.category.trim()) score += 8;
+  if (longOrigin) score += 12;
+  if (form.currentLocation.trim().length >= 8) score += 10;
+  if (form.acquiredOn) score += 6;
+  if (hasMultiplePhenomena) score += 10;
+  if (hasWitnesses) score += 12;
+  if (longCustody) score += 14;
+  if (longEvidence) score += 14;
+  if (form.incidentNotes.trim().length >= 80) score += 8;
+  if (form.attestation) score += 8;
+
+  if (!longEvidence) notes.push('Add fuller evidence notes with equipment, dates, or corroboration.');
+  if (!longCustody) notes.push('Chain of custody is too thin for archive storage.');
+  if (!hasWitnesses) notes.push('A second witness or reviewer would increase trust.');
+  if (flaggedAsJoke) {
+    score -= 45;
+    notes.push('Language suggests the report may not be intended as a serious submission.');
+  }
+
+  if (form.seriousness === 'academic') score += 6;
+  if (form.riskLevel === 'high') score += 4;
+
+  return {
+    score: Math.max(0, Math.min(100, score)),
+    flaggedAsJoke,
+    notes,
+  };
+}
+
+function badgeList(reports, level) {
+  const archived = reports.filter((report) => report.status === 'archived').length;
+  const rejected = reports.filter((report) => report.status === 'hold').length;
+  const badges = [];
+
+  if (archived >= 1) badges.push('First sealed relic');
+  if (archived >= 3) badges.push('Vault regular');
+  if (reports.some((report) => report.witnessCount >= 3)) badges.push('Multi-witness tracker');
+  if (rejected === 0 && reports.length >= 3) badges.push('Clean credibility streak');
+  if (level >= 4) badges.push('Senior custodian');
+
+  return badges;
+}
+
+function formatDate(value) {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(value));
+}
+
+function MetricCard({ label, value, caption }) {
   return (
-    <header className="topbar">
-      <div>
-        <span className="status-dot" aria-hidden="true" />
-        {activeApp.label}
+    <article className="metric-card">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <p>{caption}</p>
+    </article>
+  );
+}
+
+function SectionTitle({ eyebrow, title, body }) {
+  return (
+    <div className="section-title">
+      <p>{eyebrow}</p>
+      <h2>{title}</h2>
+      <span>{body}</span>
+    </div>
+  );
+}
+
+function ReportCard({ report, onStatusChange }) {
+  return (
+    <article className={`report-card status-${report.status}`}>
+      <div className="report-card-top">
+        <div>
+          <p className="report-status">{report.status}</p>
+          <h3>{report.objectName}</h3>
+        </div>
+        <div className="score-pill">{report.score}/100</div>
       </div>
-      <div className="topbar-meta">
-        <span>Mesh offline</span>
-        <span>GPU 38%</span>
-        <span>Fri 20:26 UTC</span>
-      </div>
-    </header>
+
+      <dl>
+        <div>
+          <dt>Category</dt>
+          <dd>{report.category}</dd>
+        </div>
+        <div>
+          <dt>Stored at</dt>
+          <dd>{report.currentLocation}</dd>
+        </div>
+        <div>
+          <dt>Witnesses</dt>
+          <dd>{report.witnessCount}</dd>
+        </div>
+        <div>
+          <dt>Phenomena</dt>
+          <dd>{report.phenomena.join(', ')}</dd>
+        </div>
+      </dl>
+
+      <p className="report-copy">{report.evidenceSummary}</p>
+      <p className="moderation-note">Moderator note: {report.moderationNote}</p>
+
+      {onStatusChange ? (
+        <div className="card-actions">
+          <button type="button" onClick={() => onStatusChange(report.id, 'archived')}>
+            Seal in storage house
+          </button>
+          <button type="button" onClick={() => onStatusChange(report.id, 'review')}>
+            Keep in review
+          </button>
+          <button type="button" className="ghost-button" onClick={() => onStatusChange(report.id, 'hold')}>
+            Hold back
+          </button>
+        </div>
+      ) : null}
+    </article>
   );
 }
 
 export default function Home() {
-  const [activeAppId, setActiveAppId] = useState('chat');
-  const [draftPrompt, setDraftPrompt] = useState(defaultPrompt);
+  const [reports, setReports] = useState(loadReports);
+  const [form, setForm] = useState(emptyForm);
+  const [activeStorageFilter, setActiveStorageFilter] = useState('all');
+  const [flash, setFlash] = useState('');
 
-  const activeApp = useMemo(
-    () => apps.find((app) => app.id === activeAppId) ?? apps[0],
-    [activeAppId],
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(reports));
+  }, [reports]);
+
+  const stats = useMemo(() => {
+    const archived = reports.filter((report) => report.status === 'archived').length;
+    const review = reports.filter((report) => report.status === 'review').length;
+    const hold = reports.filter((report) => report.status === 'hold').length;
+    const totalXp = reports.reduce((sum, report) => sum + (report.xpAwarded ?? 0), 0);
+    const level = Math.max(1, Math.floor(totalXp / levelStep) + 1);
+    const currentLevelXp = totalXp - (level - 1) * levelStep;
+    const progress = Math.min(100, Math.round((currentLevelXp / levelStep) * 100));
+
+    return {
+      archived,
+      review,
+      hold,
+      totalXp,
+      level,
+      progress,
+      levelTitle: levelTitles[Math.min(levelTitles.length - 1, level - 1)],
+      badges: badgeList(reports, level),
+    };
+  }, [reports]);
+
+  const filteredReports = useMemo(() => {
+    if (activeStorageFilter === 'all') {
+      return reports;
+    }
+
+    return reports.filter((report) => report.status === activeStorageFilter);
+  }, [activeStorageFilter, reports]);
+
+  const vettingQueue = useMemo(
+    () => reports.filter((report) => report.status === 'review' || report.status === 'hold'),
+    [reports],
   );
 
+  const handleChange = (field, value) => {
+    setForm((current) => ({ ...current, [field]: value }));
+  };
+
+  const handlePhenomenonToggle = (item) => {
+    setForm((current) => ({
+      ...current,
+      phenomena: current.phenomena.includes(item)
+        ? current.phenomena.filter((value) => value !== item)
+        : [...current.phenomena, item],
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    const review = calculateScore(form);
+    const status = review.flaggedAsJoke ? 'hold' : review.score >= 80 ? 'archived' : review.score >= 55 ? 'review' : 'hold';
+    const xpAwarded = status === 'archived' ? 140 : status === 'review' ? 85 : 20;
+    const moderationNote = review.flaggedAsJoke
+      ? 'Submission held: rewrite in a formal tone and add verifiable details.'
+      : review.notes[0] ?? 'Meets the minimum evidence bar for the current queue.';
+
+    const nextReport = {
+      id: `case-${Date.now()}`,
+      ...form,
+      status,
+      score: review.score,
+      xpAwarded,
+      moderationNote,
+      createdAt: new Date().toISOString(),
+    };
+
+    setReports((current) => [nextReport, ...current]);
+    setForm(emptyForm);
+    setFlash(
+      status === 'archived'
+        ? 'Case accepted into the storage house. Credibility XP awarded.'
+        : status === 'review'
+          ? 'Case sent to the vetting queue. Add more proof to unlock archive status.'
+          : 'Case held back. The seriousness filter detected weak or joking details.',
+    );
+  };
+
+  const handleStatusChange = (id, status) => {
+    setReports((current) =>
+      current.map((report) =>
+        report.id === id
+          ? {
+              ...report,
+              status,
+              xpAwarded:
+                status === 'archived' ? Math.max(report.xpAwarded, 140) : status === 'review' ? 90 : 20,
+              moderationNote:
+                status === 'archived'
+                  ? 'Moderator sealed this case into long-term storage.'
+                  : status === 'review'
+                    ? 'Moderator requests another evidence pass before archiving.'
+                    : 'Moderator held the report outside the archive due to credibility concerns.',
+            }
+          : report,
+      ),
+    );
+  };
+
   return (
-    <main className="os-shell">
-      <section className="hero-panel">
+    <main className="haunted-app">
+      <section className="hero-panel haunted-hero">
         <div>
-          <p className="eyebrow">Burbz OS / Offline AI cockpit</p>
-          <h1>Simple MVP operating system for your off-grid Llama AI.</h1>
+          <p className="eyebrow">Haunted object database / React MVP</p>
+          <h1>Build a serious, gamified archive for haunted objects — not campfire jokes.</h1>
           <p className="hero-copy">
-            A focused desktop-style workspace with local chat, model status, file access, and
-            power-aware controls for running disconnected.
+            This remake turns the original haunted object map idea into a React-first intake and
+            review hub with formal submissions, a storage house archive, and a trust system that
+            rewards evidence-backed fieldwork.
           </p>
           <div className="hero-focus">
-            <span className="hero-focus-label">Current focus</span>
-            <h2>{activeApp.headline}</h2>
-            <p>{activeApp.summary}</p>
+            <span className="hero-focus-label">How it works</span>
+            <h2>Detailed forms enter a vetting queue before public archive placement.</h2>
+            <p>
+              Every report is scored for seriousness, witness quality, chain of custody, and depth
+              of evidence. Strong cases enter the storage house immediately, while weak or joking
+              entries are held back for moderator review.
+            </p>
           </div>
         </div>
 
-        <StatusCardList items={systemStats} />
+        <div className="hero-stats haunted-metrics">
+          <MetricCard
+            label="Archived relics"
+            value={stats.archived}
+            caption="Cases currently sealed in the storage house."
+          />
+          <MetricCard
+            label="Vetting queue"
+            value={stats.review + stats.hold}
+            caption="Reports awaiting approval, edits, or rejection."
+          />
+          <MetricCard
+            label="Credibility level"
+            value={`Lv.${stats.level}`}
+            caption={`${stats.levelTitle} • ${stats.totalXp} XP banked.`}
+          />
+        </div>
       </section>
 
-      <section className="desktop-frame" aria-label="Off-grid Llama desktop">
-        <Dock apps={apps} activeApp={activeAppId} onSelect={setActiveAppId} />
+      <section className="dashboard-grid">
+        <article className="panel panel-form">
+          <SectionTitle
+            eyebrow="1. Field intake"
+            title="Detailed haunted object submission"
+            body="Collect facts the way an archivist or investigator would."
+          />
 
-        <div className="workspace">
-          <TopBar activeApp={activeApp} />
-
-          <div className="window-grid">
-            <section className="window chat-window">
-              <AppWorkspace
-                activeApp={activeApp}
-                draftPrompt={draftPrompt}
-                onDraftChange={setDraftPrompt}
+          <form className="intake-form" onSubmit={handleSubmit}>
+            <label>
+              Object name
+              <input
+                value={form.objectName}
+                onChange={(event) => handleChange('objectName', event.target.value)}
+                placeholder="Ex: Blackthorn Mourning Locket"
+                required
               />
-            </section>
+            </label>
 
-            <section className="sidebar-stack">
-              <WindowPanel title="Quick prompts" compact>
-                <div className="chip-list">
-                  {quickPrompts.map((prompt) => (
-                    <button
-                      key={prompt}
-                      type="button"
-                      className="chip"
-                      onClick={() => setDraftPrompt(prompt)}
-                    >
-                      {prompt}
-                    </button>
+            <div className="form-split">
+              <label>
+                Category
+                <input
+                  value={form.category}
+                  onChange={(event) => handleChange('category', event.target.value)}
+                  placeholder="Artifact, furniture, jewelry..."
+                  required
+                />
+              </label>
+
+              <label>
+                Witness count
+                <input
+                  type="number"
+                  min="1"
+                  value={form.witnessCount}
+                  onChange={(event) => handleChange('witnessCount', Number(event.target.value))}
+                  required
+                />
+              </label>
+            </div>
+
+            <label>
+              Origin and provenance
+              <textarea
+                value={form.origin}
+                onChange={(event) => handleChange('origin', event.target.value)}
+                placeholder="Explain where the object came from, who handled it, and why it matters."
+                required
+              />
+            </label>
+
+            <div className="form-split">
+              <label>
+                Current storage location
+                <input
+                  value={form.currentLocation}
+                  onChange={(event) => handleChange('currentLocation', event.target.value)}
+                  placeholder="Shelf, vault, locker, museum room..."
+                  required
+                />
+              </label>
+
+              <label>
+                Acquisition date
+                <input
+                  type="date"
+                  value={form.acquiredOn}
+                  onChange={(event) => handleChange('acquiredOn', event.target.value)}
+                  required
+                />
+              </label>
+            </div>
+
+            <fieldset>
+              <legend>Reported phenomena</legend>
+              <div className="check-grid">
+                {phenomenonOptions.map((item) => (
+                  <label key={item} className="check-pill">
+                    <input
+                      type="checkbox"
+                      checked={form.phenomena.includes(item)}
+                      onChange={() => handlePhenomenonToggle(item)}
+                    />
+                    <span>{item}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <label>
+              Chain of custody
+              <textarea
+                value={form.chainOfCustody}
+                onChange={(event) => handleChange('chainOfCustody', event.target.value)}
+                placeholder="Document the transfer history from previous owner to current vault."
+                required
+              />
+            </label>
+
+            <label>
+              Evidence summary
+              <textarea
+                value={form.evidenceSummary}
+                onChange={(event) => handleChange('evidenceSummary', event.target.value)}
+                placeholder="Describe interviews, recordings, environmental readings, or sworn testimony."
+                required
+              />
+            </label>
+
+            <label>
+              Incident notes
+              <textarea
+                value={form.incidentNotes}
+                onChange={(event) => handleChange('incidentNotes', event.target.value)}
+                placeholder="Keep speculation separate from observed events."
+                required
+              />
+            </label>
+
+            <div className="form-split triple">
+              <label>
+                Report style
+                <select
+                  value={form.seriousness}
+                  onChange={(event) => handleChange('seriousness', event.target.value)}
+                >
+                  {seriousnessOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
                   ))}
-                </div>
-              </WindowPanel>
+                </select>
+              </label>
 
-              <WindowPanel title="System health" compact>
-                <SystemHealthList />
-              </WindowPanel>
+              <label>
+                Risk level
+                <select value={form.riskLevel} onChange={(event) => handleChange('riskLevel', event.target.value)}>
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                </select>
+              </label>
 
-              <WindowPanel title="Offline vault" compact>
-                <FileList />
-              </WindowPanel>
-            </section>
+              <label>
+                Submitted by
+                <input
+                  value={form.submittedBy}
+                  onChange={(event) => handleChange('submittedBy', event.target.value)}
+                  placeholder="Investigator or archive team"
+                  required
+                />
+              </label>
+            </div>
+
+            <label className="attestation">
+              <input
+                type="checkbox"
+                checked={form.attestation}
+                onChange={(event) => handleChange('attestation', event.target.checked)}
+              />
+              <span>
+                I confirm this is a serious submission intended for archival review, not a joke or
+                fictional post.
+              </span>
+            </label>
+
+            <button type="submit" className="primary-button">
+              Submit haunted object case
+            </button>
+
+            {flash ? <p className="flash-message">{flash}</p> : null}
+          </form>
+        </article>
+
+        <article className="panel">
+          <SectionTitle
+            eyebrow="2. Credibility engine"
+            title="Automated seriousness vetting"
+            body="A lightweight moderation system for the MVP."
+          />
+
+          <div className="rubric-list">
+            <div>
+              <strong>High trust signals</strong>
+              <p>Long-form evidence, clear custody records, 2+ witnesses, and formal attestation.</p>
+            </div>
+            <div>
+              <strong>Hold triggers</strong>
+              <p>Thin provenance, meme language, no corroboration, or vague storage details.</p>
+            </div>
+            <div>
+              <strong>Queue logic</strong>
+              <p>80+ auto-archives, 55-79 enters review, and lower scores stay on hold.</p>
+            </div>
           </div>
-        </div>
+
+          <div className="queue-stack">
+            {vettingQueue.map((report) => (
+              <ReportCard key={report.id} report={report} onStatusChange={handleStatusChange} />
+            ))}
+            {!vettingQueue.length ? <p className="empty-state">No cases waiting — the vault team is caught up.</p> : null}
+          </div>
+        </article>
+      </section>
+
+      <section className="dashboard-grid lower-grid">
+        <article className="panel">
+          <SectionTitle
+            eyebrow="3. Storage house"
+            title="Archived forms and sealed object records"
+            body="Every form is persisted locally for MVP review and archive browsing."
+          />
+
+          <div className="filter-row">
+            {['all', 'archived', 'review', 'hold'].map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                className={activeStorageFilter === filter ? 'is-active' : ''}
+                onClick={() => setActiveStorageFilter(filter)}
+              >
+                {filter}
+              </button>
+            ))}
+          </div>
+
+          <div className="storage-grid">
+            {filteredReports.map((report) => (
+              <article key={report.id} className="storage-card">
+                <div className="storage-top">
+                  <div>
+                    <p>{report.category}</p>
+                    <h3>{report.objectName}</h3>
+                  </div>
+                  <span>{report.status}</span>
+                </div>
+                <ul>
+                  <li>Stored at: {report.currentLocation}</li>
+                  <li>Acquired: {formatDate(report.acquiredOn || report.createdAt)}</li>
+                  <li>Filed by: {report.submittedBy}</li>
+                  <li>Phenomena: {report.phenomena.join(', ')}</li>
+                </ul>
+              </article>
+            ))}
+          </div>
+        </article>
+
+        <article className="panel">
+          <SectionTitle
+            eyebrow="4. Gamification"
+            title="Level up like a trusted field network"
+            body="Inspired by crowd-powered progress systems, but tailored to paranormal archive work."
+          />
+
+          <div className="level-panel">
+            <div>
+              <p className="level-label">Current rank</p>
+              <h3>
+                Level {stats.level}: {stats.levelTitle}
+              </h3>
+              <p>
+                Your archive reputation grows when you submit serious reports, help moderators seal
+                review cases, and avoid flimsy or joking entries.
+              </p>
+            </div>
+            <div className="level-progress">
+              <div className="progress-bar">
+                <span style={{ width: `${stats.progress}%` }} />
+              </div>
+              <strong>{stats.progress}% to next level</strong>
+            </div>
+          </div>
+
+          <div className="badge-wrap">
+            {stats.badges.map((badge) => (
+              <span key={badge} className="badge-pill">
+                {badge}
+              </span>
+            ))}
+            {!stats.badges.length ? <span className="badge-pill muted">No badges yet</span> : null}
+          </div>
+
+          <div className="quest-list">
+            {quests.map((quest) => (
+              <article key={quest.title}>
+                <div>
+                  <p>{quest.reward}</p>
+                  <h3>{quest.title}</h3>
+                </div>
+                <span>{quest.detail}</span>
+              </article>
+            ))}
+          </div>
+        </article>
       </section>
     </main>
   );


### PR DESCRIPTION
### Motivation
- Replace the previous off-grid Llama desktop concept with a focused React MVP that captures, vets, and archives haunted-object reports in a way that discourages joking or low-effort submissions. 
- Provide a local-first prototype for submission intake, automated seriousness scoring, moderator actions, and a lightweight gamification loop to encourage high-quality contributions.

### Description
- Add a data module `src/data/hauntedMvp.js` that seeds `starterReports`, `phenomenonOptions`, `seriousnessOptions`, `levelTitles`, and `quests` to drive the MVP UI and progression rules. 
- Replace the main screen with a single-page React intake and review UI in `src/pages/Home.jsx` implementing a detailed form, automated scoring (`calculateScore`), an anti-joke regex filter, moderation actions, XP/level calculation, badges, and local vetting/storage flows. 
- Update styling in `src/index.css` to a dark, responsive dashboard layout tailored to the haunted-archive product, and refresh `README.md` to describe the new MVP features and local persistence approach. 
- Persist reports to browser storage via `localStorage` (`storageKey = 'haunted-object-mvp-reports'`) and surface reviewer actions that move reports between `archived`, `review`, and `hold` states while awarding XP.

### Testing
- Built the production bundle with `npm run build`, which completed successfully (`vite build` produced `dist/` assets`).
- No automated unit tests were present; the build is the only automated verification executed and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd56e5eec483338e29ed6d6f1bf860)